### PR TITLE
Replaced Deprecated Features

### DIFF
--- a/cfg/NEO_mackmind_SonicPad_printer.cfg
+++ b/cfg/NEO_mackmind_SonicPad_printer.cfg
@@ -217,7 +217,7 @@ horizontal_move_z: 10
 mesh_min: 32, 26
 mesh_max: 189, 189
 probe_count: 5, 5
-relative_reference_index: 13
+zero_reference_position: 72.5, 106
 algorithm: lagrange
 
 [screws_tilt_adjust]
@@ -263,7 +263,8 @@ cycle_time: 0.000050 #= 20kHz as this seems to be the frequency in the stock fir
 [output_pin enable_pin]
 #This is the pin controls bed, hotend, extruder fan, part fan.
 pin: PB6
-static_value: 1
+value: 1
+shutdown_value: 0
 
 #[output_pin beeper]
 #pin: PB7


### PR DESCRIPTION
Replaced features deprecated by Klipper updates 20240123 and 20240215

https://www.klipper3d.org/Config_Changes.html

`relative_reference_index` --> `zero_reference_position`

`static_value` --> `value` and `shutdown_value`